### PR TITLE
Enforce aws-java-sdk-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,12 @@
 
     <dependency>
       <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-core</artifactId>
+      <version>${aws-java-sdk.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-secretsmanager</artifactId>
       <version>${aws-java-sdk.version}</version>
     </dependency>


### PR DESCRIPTION
If version of `com.amazonaws:aws-java-sdk-core` is less than the version of `com.amazonaws:aws-java-sdk-secretsmanager`, it will throw an exception with this message `java.lang.NoSuchFieldError: SIGNING_REGION` when it tries to instantiate.